### PR TITLE
Fix for event_name check in CI/CD

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
         # outputs `steps.get_tag.outputs.VERSION`
         shell: bash
         run: |
-          if [[ ${{ github.event_name == 'pull_request' }} ]]; then
+          if [[ '${{ github.event_name }}' == 'pull_request' ]] ; then
             echo "Is a PR, not a tag; setting version envvar to 0.0.0-PR"
             echo "::set-output name=VERSION::0.0.0-PR"
             exit 0


### PR DESCRIPTION
I accidentally made the CI/CD pipeline check `if [[ false ]] ; then` which definitely doesn't operate how I intended (it evals true).
After this fix, the deployment pipeline should not publish with version `0.0.0-PR` which is dedicated to PRs.