### PR TITLE
[WIP] Omnibus: heavy testing, enhancements, documentation, etc etc

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Restore solution dependencies
         run: dotnet restore
       - name: Tests
-        run: ./Org.Grush.Lib.RecordCollections.Tests/run-tests.sh
+        run: bash ./Org.Grush.Lib.RecordCollections.Tests/run-tests.sh
       - name: Code coverage
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,7 +55,14 @@ jobs:
       - name: Restore solution dependencies
         run: dotnet restore
       - name: Tests
-        run: dotnet test ./Org.Grush.Lib.RecordCollections.Tests --no-restore
+        run: ./Org.Grush.Lib.RecordCollections.Tests/run-tests.sh
+      - name: Code coverage
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: ./Org.Grush.Lib.RecordCollections.Tests/TestResults/**/coverage.cobertura.xml
+          badge: true
+          fail_below_min: true
+          thresholds: '100 100'
       - name: AOT Tests
         run: ./Org.Grush.Lib.RecordCollections.AotTests/run-aot-test.sh
       - name: Pack

--- a/Org.Grush.Lib.RecordCollections.Newtonsoft/README.md
+++ b/Org.Grush.Lib.RecordCollections.Newtonsoft/README.md
@@ -1,5 +1,10 @@
 # `RecordCollection<T>` Newtonsoft serialization extension
 
+Newtonsoft extension for the `Org.Grush.Lib.RecordCollections` core package
+(see the core package's
+[NuGet package](https://www.nuget.org/packages/Org.Grush.Lib.RecordCollections) or
+[GitHub source](https://github.com/skgrush/Org.Grush.Lib.RecordCollections/tree/main/Org.Grush.Lib.RecordCollections)).
+
 ## Example
 
 Specific usage where collection types are known:

--- a/Org.Grush.Lib.RecordCollections.Newtonsoft/RecordCollectionNewtonsoftJsonConverter.cs
+++ b/Org.Grush.Lib.RecordCollections.Newtonsoft/RecordCollectionNewtonsoftJsonConverter.cs
@@ -8,9 +8,7 @@ public class RecordCollectionNewtonsoftJsonConverter<T> : JsonConverter<RecordCo
   public override bool CanWrite => false;
 
   public override void WriteJson(JsonWriter writer, RecordCollection<T> value, JsonSerializer serializer)
-  {
-    serializer.Serialize(writer, value, typeof(IImmutableList<T>));
-  }
+    => throw new NotSupportedException();
 
   public override RecordCollection<T> ReadJson(JsonReader reader, Type objectType, RecordCollection<T> existingValue, bool hasExistingValue,
     JsonSerializer serializer)

--- a/Org.Grush.Lib.RecordCollections.Tests/ForDeserializability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForDeserializability.cs
@@ -9,11 +9,11 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 namespace Org.Grush.Lib.RecordCollections.Tests;
 
 [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
-public class ForDeserializability
+public static class ForDeserializability
 {
   [Theory]
   [ClassData(typeof(RuntimeDeserializers<RecordCollection<string?>>))]
-  public void AtRuntime_WithSingleLayer(string name, Func<string, RecordCollection<string?>> deserializer)
+  public static void AtRuntime_WithSingleLayer(string name, Func<string, RecordCollection<string?>> deserializer)
   {
     const string json =
       """
@@ -28,7 +28,7 @@ public class ForDeserializability
   [Theory]
   [ClassData(
     typeof(RuntimeDeserializers<RecordCollection<TestRecord<RecordCollection<int>, RecordCollection<string>>>>))]
-  public void AtRuntime_WithMultipleLayers(string name,
+  public static void AtRuntime_WithMultipleLayers(string name,
     Func<string, RecordCollection<TestRecord<RecordCollection<int>, RecordCollection<string>>>> deserializer)
   {
     const string json =
@@ -46,10 +46,10 @@ public class ForDeserializability
       ]));
   }
 
-  public class WithSourceGeneratedDeserializer
+  public static class WithSourceGeneratedDeserializer
   {
     [Fact]
-    public void WhenEmptyArray()
+    public static void WhenEmptyArray()
     {
       const string json = "[]";
 
@@ -62,7 +62,7 @@ public class ForDeserializability
     }
 
     [Fact]
-    public void InSimpleCase()
+    public static void InSimpleCase()
     {
       const string json =
         """
@@ -78,7 +78,7 @@ public class ForDeserializability
     }
 
     [Fact]
-    public void WithNonStandardSettings()
+    public static void WithNonStandardSettings()
     {
       const string json =
         """
@@ -107,7 +107,7 @@ public class ForDeserializability
     [InlineData("no end", "[ 1, 2, 3 ")]
     [InlineData("no end", "[ 1, 2, 3 , ")]
     [InlineData("no brackets", " 1, 2, 3")]
-    public void ThrowJsonExceptionWhen(string _, string json)
+    public static void ThrowJsonExceptionWhen(string _, string json)
     {
       // Assemble
       Action act = () =>

--- a/Org.Grush.Lib.RecordCollections.Tests/ForEquatability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForEquatability.cs
@@ -6,10 +6,10 @@ using Xunit.Sdk;
 
 namespace Org.Grush.Lib.RecordCollections.Tests;
 
-public class ForEquatability
+public static class ForEquatability
 {
   [Fact]
-  public void WhenContainingValueTypes()
+  public static void WhenContainingValueTypes()
   {
     // Assemble
     RecordCollection<int> collectionA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -23,7 +23,7 @@ public class ForEquatability
   }
 
   [Fact]
-  public void WhenContainingReferenceTypes()
+  public static void WhenContainingReferenceTypes()
   {
     // Assemble
     var collectionA = RecordCollection.Create([new TestRecordOfInts(1, 2), new TestRecordOfInts(3, 4)]);
@@ -45,7 +45,7 @@ public class ForEquatability
   [InlineData(false, true)]
   [InlineData(true, false)]
   [InlineData(true, true)]
-  public void AndEqualWithNullValues(bool oneEmpty, bool reversed)
+  public static void AndEqualWithNullValues(bool oneEmpty, bool reversed)
   {
     // Assemble
     RecordCollection<int>? collectionA = oneEmpty ? [] : [1, 2, 3];
@@ -67,7 +67,7 @@ public class ForEquatability
   }
 
   [Fact]
-  public void ForUseInDictionaries()
+  public static void ForUseInDictionaries()
   {
     // Assemble
     RecordCollection<string> collectionA = ["a", "b"];
@@ -91,7 +91,7 @@ public class ForEquatability
   }
 
   [Fact]
-  public void ForUseInHashSets()
+  public static void ForUseInHashSets()
   {
     // Assemble
     RecordCollection<double> collectionA = [3.14159, double.PositiveInfinity];
@@ -114,7 +114,7 @@ public class ForEquatability
   }
 
   [Fact]
-  public void AsMembersOfRecords()
+  public static void AsMembersOfRecords()
   {
     // Assemble
     var recordA = new TestRecordOfCollections([1, 2], [3, 4]);
@@ -166,7 +166,7 @@ public class ForEquatability
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void WhenNeitherNull(bool shouldBeEqual)
+    public static void WhenNeitherNull(bool shouldBeEqual)
     {
       // Assemble
       RecordCollection<int>? collB = [1, 2, 3];
@@ -180,7 +180,7 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenBothNull()
+    public static void WhenBothNull()
     {
       RecordCollection<string>.Equals(null, null)
         .Should()
@@ -190,7 +190,7 @@ public class ForEquatability
     [Theory]
     [InlineData(false, true)]
     [InlineData(true, false)]
-    public void WhenMismatchedNullable(bool firstIsNull, bool secondIsNull)
+    public static void WhenMismatchedNullable(bool firstIsNull, bool secondIsNull)
     {
       // Assemble
       RecordCollection<int>? firstColl = firstIsNull ? null : [1, 2, 3, 4];
@@ -204,10 +204,10 @@ public class ForEquatability
     }
   }
 
-  public class Structural
+  public static class Structural
   {
     [Fact]
-    public void ShouldReturnFalseAgainstNull()
+    public static void ShouldReturnFalseAgainstNull()
     {
       RecordCollection<int> collectionA = [1, 2, 3];
       RecordCollection<int>? collectionB = null;
@@ -222,12 +222,12 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenComparerIsOfT_AndOtherIsRecordCollectionOfT_ShouldUseTComparer()
+    public static void WhenComparerIsOfT_AndOtherIsRecordCollectionOfT_ShouldUseTComparer()
     {
       RecordCollection<byte> collectionA = [1, 2, 3];
       RecordCollection<byte>? collectionB = [1, 2, 3];
 
-      var comparerMock = MakeComparerOf<byte>(null, null);
+      var comparerMock = MakeComparerOf<byte>();
       comparerMock.Setup(c => c.Equals(It.IsAny<byte>(), It.IsAny<byte>())).Returns(true);
 
       var areEqual = ((IStructuralEquatable)collectionA).Equals(collectionB, (IEqualityComparer)comparerMock.Object);
@@ -238,11 +238,11 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenComparerIsOfT_AndOtherIsIEnumerableOfT_ShouldUseTComparer()
+    public static void WhenComparerIsOfT_AndOtherIsIEnumerableOfT_ShouldUseTComparer()
     {
       RecordCollection<byte> collectionA = [1, 2, 3];
       IEnumerable<byte> enumerableB = Enumerable.Range(1, 3).Select(x => (byte)x);
-      var comparer = MakeComparerOf<byte>(null, null);
+      var comparer = MakeComparerOf<byte>();
       comparer.Setup(c => c.Equals(It.IsAny<byte>(), It.IsAny<byte>())).Returns((byte a, byte b) => a == b);
 
       var areEqual = ((IStructuralEquatable)collectionA).Equals(enumerableB, (IEqualityComparer)comparer.Object);
@@ -253,11 +253,11 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenToStructuralEquatable_ButNotEnumerable()
+    public static void WhenToStructuralEquatable_ButNotEnumerable()
     {
       RecordCollection<uint> collectionA = [1, 2, 3];
 
-      var comparer = MakeComparerOf<uint>(null, null);
+      var comparer = MakeComparerOf<uint>();
       comparer.Setup(c => c.GetHashCode(It.IsIn(1u, 2u, 3u))).Returns((uint i) => (int)i);
 
       int hashOfCollectionA = ((IStructuralEquatable)collectionA).GetHashCode((IEqualityComparer)comparer.Object);
@@ -276,11 +276,11 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenComparerIsOfT_ButOtherIsNotEnumerableOfT_ShouldFallbackToEnumerable_AndFailLazily()
+    public static void WhenComparerIsOfT_ButOtherIsNotEnumerableOfT_ShouldFallbackToEnumerable_AndFailLazily()
     {
       RecordCollection<uint> collectionA = [1, 2, 3];
       RecordCollection<int> collectionB = [1, 22, 3];
-      var comparerMock = MakeComparer(null);
+      var comparerMock = MakeComparer();
       comparerMock.Setup(c => c.Equals(1u, 1)).Returns(true);
       comparerMock.Setup(c => c.Equals(2u, 22)).Returns(false);
       // lazily doesn't evaluate third item
@@ -293,7 +293,7 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenOtherIsEnumerableOfOther_UseComparerEquals()
+    public static void WhenOtherIsEnumerableOfOther_UseComparerEquals()
     {
       RecordCollection<uint> collectionA = [1, 2, 3];
       IEnumerable<double> enumerableB = Enumerable.Range(1, 3).Select(x => x + 0.4);
@@ -307,7 +307,7 @@ public class ForEquatability
     [Theory]
     [InlineData(3, 4)]
     [InlineData(4, 3)]
-    public void WhenOtherIsEnumerableOfOther_UseComparerEquals_AndFailForMismatchedLength(int len1, int len2)
+    public static void WhenOtherIsEnumerableOfOther_UseComparerEquals_AndFailForMismatchedLength(int len1, int len2)
     {
       RecordCollection<int> collectionA = Enumerable.Range(1, len1).ToRecordCollection();
       IEnumerable<long> enumerableB = Enumerable.Range(1, len2).Select(x => (long)x);
@@ -321,7 +321,7 @@ public class ForEquatability
     }
 
     [Fact]
-    public void WhenOtherIsEnumerableOfOther_UseComparerEquals_AndFailForMismatchedValues()
+    public static void WhenOtherIsEnumerableOfOther_UseComparerEquals_AndFailForMismatchedValues()
     {
       RecordCollection<int> collectionA = [5, 6, 7];
       IEnumerable<long> enumerableB = Enumerable.Range(1, 3).Select(x => (long)x);
@@ -333,7 +333,7 @@ public class ForEquatability
     }
 
     [Fact]
-    public void FailForNonEnumerable()
+    public static void FailForNonEnumerable()
     {
       RecordCollection<int> collectionA = [1, 2, 3];
       object otherThing = new { unique = true };
@@ -345,7 +345,7 @@ public class ForEquatability
     }
 
     [Fact]
-    public void ShortCircuitForDifferentSizedCollections()
+    public static void ShortCircuitForDifferentSizedCollections()
     {
       RecordCollection<int> collectionA = [1, 2, 3];
 
@@ -361,7 +361,7 @@ public class ForEquatability
     }
 
     [Fact]
-    public void GetHashCode_ForComparerNotOfT_ForValueType()
+    public static void GetHashCode_ForComparerNotOfT_ForValueType()
     {
       RecordCollection<int?> collectionA = [1, 2, 3, null];
 

--- a/Org.Grush.Lib.RecordCollections.Tests/ForEquatability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForEquatability.cs
@@ -9,14 +9,6 @@ namespace Org.Grush.Lib.RecordCollections.Tests;
 public class ForEquatability
 {
   [Fact]
-  public void AgainstSpan()
-  {
-    RecordCollection<int> collectionA = [1, 2, 3];
-
-    var eq = collectionA == [1, 2, 3];
-  }
-
-  [Fact]
   public void WhenContainingValueTypes()
   {
     // Assemble

--- a/Org.Grush.Lib.RecordCollections.Tests/ForEquatability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForEquatability.cs
@@ -1,16 +1,27 @@
+using System.Collections;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Moq;
+using Xunit.Sdk;
 
 namespace Org.Grush.Lib.RecordCollections.Tests;
 
 public class ForEquatability
 {
   [Fact]
+  public void AgainstSpan()
+  {
+    RecordCollection<int> collectionA = [1, 2, 3];
+
+    var eq = collectionA == [1, 2, 3];
+  }
+
+  [Fact]
   public void WhenContainingValueTypes()
   {
     // Assemble
-    RecordCollection<int> collectionA = [1, 2, 3];
-    RecordCollection<int> collectionB = [1, 2, 3];
+    RecordCollection<int> collectionA = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    RecordCollection<int> collectionB = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     // Act
     var areEqual = Equals(collectionA, collectionB);
@@ -160,6 +171,216 @@ public class ForEquatability
 
       // Assert
       areEqual.Should().BeFalse();
+    }
+  }
+
+  public class Structural
+  {
+    [Fact]
+    public void ShouldReturnFalseAgainstNull()
+    {
+      RecordCollection<int> collectionA = [1, 2, 3];
+      RecordCollection<int>? collectionB = null;
+
+      var comparerMock = MakeAlwaysTrueComparer();
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(collectionB, comparerMock.Object);
+
+      areEqual.Should().BeFalse();
+      comparerMock.Verify(m => m.Equals(It.IsAny<int>(), It.IsAny<long>()), Times.Never);
+      comparerMock.Verify(m => m.GetHashCode(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public void WhenComparerIsOfT_AndOtherIsRecordCollectionOfT_ShouldUseTComparer()
+    {
+      RecordCollection<byte> collectionA = [1, 2, 3];
+      RecordCollection<byte>? collectionB = [1, 2, 3];
+
+      var comparerMock = MakeComparerOf<byte>(null, null);
+      comparerMock.Setup(c => c.Equals(It.IsAny<byte>(), It.IsAny<byte>())).Returns(true);
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(collectionB, (IEqualityComparer)comparerMock.Object);
+
+      areEqual.Should().BeTrue();
+
+      comparerMock.Verify(c => c.Equals(It.IsAny<byte>(), It.IsAny<byte>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public void WhenComparerIsOfT_AndOtherIsIEnumerableOfT_ShouldUseTComparer()
+    {
+      RecordCollection<byte> collectionA = [1, 2, 3];
+      IEnumerable<byte> enumerableB = Enumerable.Range(1, 3).Select(x => (byte)x);
+      var comparer = MakeComparerOf<byte>(null, null);
+      comparer.Setup(c => c.Equals(It.IsAny<byte>(), It.IsAny<byte>())).Returns((byte a, byte b) => a == b);
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(enumerableB, (IEqualityComparer)comparer.Object);
+
+      areEqual.Should().BeTrue();
+
+      comparer.Verify(c => c.Equals(It.IsAny<byte>(), It.IsAny<byte>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public void WhenComparerIsOfT_ButOtherIsNotEnumerableOfT_ShouldFallbackToStructuralEquatable()
+    {
+      RecordCollection<uint> collectionA = [1, 2, 3];
+      RecordCollection<int> collectionB = [1, 2, 3];
+      var comparer = MakeComparerOf<uint>(null, null);
+      comparer.Setup(c => c.GetHashCode(It.IsAny<uint>())).Returns((uint i) => (int)i);
+      comparer.As<IEqualityComparer>().Setup(c => c.GetHashCode(It.IsIn(1, 2, 3))).Returns((int i) => i);
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(collectionB, (IEqualityComparer)comparer.Object);
+
+      areEqual.Should().BeTrue();
+
+      comparer.Verify(c => c.GetHashCode(It.IsAny<uint>()), Times.Exactly(3));
+      comparer.As<IEqualityComparer>().Verify(c => c.GetHashCode(It.IsAny<object>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public void WhenComparerIsOfT_ButOtherIsNotEnumerableOfT_ShouldFallbackToStructuralEquatable_AndFailForMismatch()
+    {
+      RecordCollection<uint> collectionA = [1, 2, 3];
+      RecordCollection<int> collectionB = [1, 22, 3];
+      var comparer = MakeComparerOf<uint>(null, null);
+      comparer.Setup(c => c.GetHashCode(It.IsAny<uint>())).Returns((uint i) => (int)i);
+      comparer.As<IEqualityComparer>().Setup(c => c.GetHashCode(It.IsIn(1, 22, 3))).Returns((int i) => i);
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(collectionB, (IEqualityComparer)comparer.Object);
+
+      areEqual.Should().BeFalse();
+
+      comparer.Verify(c => c.GetHashCode(It.IsAny<uint>()), Times.Exactly(3));
+      comparer.As<IEqualityComparer>().Verify(c => c.GetHashCode(It.IsAny<object>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public void WhenOtherIsEnumerableOfOther_UseComparerEquals()
+    {
+      RecordCollection<uint> collectionA = [1, 2, 3];
+      IEnumerable<double> enumerableB = Enumerable.Range(1, 3).Select(x => x + 0.4);
+      IntegralComparer comparer = new();
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(enumerableB, comparer);
+
+      areEqual.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(3, 4)]
+    [InlineData(4, 3)]
+    public void WhenOtherIsEnumerableOfOther_UseComparerEquals_AndFailForMismatchedLength(int len1, int len2)
+    {
+      RecordCollection<int> collectionA = Enumerable.Range(1, len1).ToRecordCollection();
+      IEnumerable<long> enumerableB = Enumerable.Range(1, len2).Select(x => (long)x);
+      var comparerMock = MakeAlwaysTrueComparer();
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(enumerableB, comparerMock.Object);
+
+      areEqual.Should().BeFalse();
+      comparerMock.Verify(m => m.Equals(It.IsAny<int>(), It.IsAny<long>()), Times.Exactly(3));
+      comparerMock.Verify(m => m.GetHashCode(It.IsAny<object>()), Times.Never);
+    }
+
+    [Fact]
+    public void WhenOtherIsEnumerableOfOther_UseComparerEquals_AndFailForMismatchedValues()
+    {
+      RecordCollection<int> collectionA = [5, 6, 7];
+      IEnumerable<long> enumerableB = Enumerable.Range(1, 3).Select(x => (long)x);
+      IntegralComparer comparer = new();
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(enumerableB, comparer);
+
+      areEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FailForNonEnumerable()
+    {
+      RecordCollection<int> collectionA = [1, 2, 3];
+      object otherThing = new { unique = true };
+      Mock<IEqualityComparer> comparer = new(MockBehavior.Strict);
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(otherThing, comparer.Object);
+
+      areEqual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShortCircuitForDifferentSizedCollections()
+    {
+      RecordCollection<int> collectionA = [1, 2, 3];
+
+      var maxCollectionMoq = new Mock<IReadOnlyCollection<int>>(MockBehavior.Strict);
+      maxCollectionMoq.SetupGet(x => x.Count).Returns(int.MaxValue);
+      maxCollectionMoq.Setup(x => x.GetEnumerator()).Throws(() => FailException.ForFailure("called GetEnumerator"));
+
+      var comparerMock = MakeAlwaysTrueComparer();
+
+      var areEqual = ((IStructuralEquatable)collectionA).Equals(maxCollectionMoq.Object, comparerMock.Object);
+
+      areEqual.Should().BeFalse();
+    }
+
+
+    private Mock<IEqualityComparer> MakeComparer(IEqualityComparer? basedOn)
+    {
+      var mock = new Mock<IEqualityComparer>(MockBehavior.Strict);
+
+      if (basedOn is not null)
+      {
+        mock
+          .Setup(c => c.Equals(It.IsAny<object>(), It.IsAny<object>()))
+          .Callback((object a, object b) => basedOn.Equals(a, b));
+
+        mock
+          .Setup(c => c.GetHashCode(It.IsAny<object>()))
+          .Callback((object a) => basedOn.GetHashCode(a));
+      }
+
+      return mock;
+    }
+
+    private Mock<IEqualityComparer<T>> MakeComparerOf<T>(IEqualityComparer<T>? basedOnOfT, IEqualityComparer? basedOn)
+    {
+      var mock = MakeComparer(basedOn);
+      var comparerOfT = mock.As<IEqualityComparer<T>>();
+
+      if (basedOnOfT is not null)
+      {
+        comparerOfT
+          .Setup(c => c.Equals(It.IsAny<T>(), It.IsAny<T>()))
+          .Callback((T? a, T? b) => basedOnOfT.Equals(a, b));
+
+        comparerOfT
+          .Setup(c => c.GetHashCode(It.IsAny<T>()!))
+          .Callback((T a) => basedOnOfT.GetHashCode(a));
+      }
+
+      return comparerOfT;
+    }
+
+    private Mock<IEqualityComparer> MakeAlwaysTrueComparer()
+    {
+      var mock = new Mock<IEqualityComparer>(MockBehavior.Strict);
+      mock.Setup(x => x.Equals(It.IsAny<object>(), It.IsAny<object>())).Returns(true);
+      mock.Setup(x => x.GetHashCode(It.IsAny<object>())).Returns(1);
+      return mock;
+    }
+
+    private class IntegralComparer : IEqualityComparer
+    {
+      bool IEqualityComparer.Equals(object? x, object? y) =>
+        (x, y) switch
+        {
+          (null, null) => true,
+          (not null, not null) => Convert.ToInt64(x) == Convert.ToInt64(y),
+          _ => false,
+        };
+
+      public int GetHashCode(object obj) => Convert.ToInt64(obj).GetHashCode();
     }
   }
 }

--- a/Org.Grush.Lib.RecordCollections.Tests/ForImmutability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForImmutability.cs
@@ -22,6 +22,36 @@ public class ForImmutability
       .BeTrue();
   }
 
+  [Fact]
+  public void ItemRefIsReadOnly()
+  {
+    var collection = RecordCollection.Create([
+      (Key: 1, Prop: "A"),
+      (Key: 2, Prop: "B"),
+    ]);
+
+    collection[0].Should().NotBeSameAs(collection[0]);
+
+    unsafe
+    {
+      fixed ((int Key, string Prop)* pa = &collection.ItemRef(0), pb = &collection.ItemRef(0))
+      {
+        (pa == pb).Should().BeTrue();
+      }
+    }
+  }
+
+  [Fact]
+  public void AsSpanAndAsMemoryAreSame()
+  {
+    RecordCollection<string> collection = ["a", "b"];
+
+    var span = collection.AsSpan();
+    var mem = collection.AsMemory();
+
+    (mem.Span == span).Should().BeTrue();
+  }
+
   [Theory]
   [ClassData(typeof(UnsupportedMethods))]
   public void AndThrowForUnsupportedMethods(string name, Action action)

--- a/Org.Grush.Lib.RecordCollections.Tests/ForImmutability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForImmutability.cs
@@ -7,10 +7,10 @@ using FluentAssertions.Execution;
 namespace Org.Grush.Lib.RecordCollections.Tests;
 
 [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
-public class ForImmutability
+public static class ForImmutability
 {
   [Fact]
-  public void AndAlwaysReadOnly()
+  public static void AndAlwaysReadOnly()
   {
     using var _ = new AssertionScope();
 
@@ -23,7 +23,7 @@ public class ForImmutability
   }
 
   [Fact]
-  public void ItemRefIsReadOnly()
+  public static void ItemRefIsReadOnly()
   {
     var collection = RecordCollection.Create([
       (Key: 1, Prop: "A"),
@@ -42,7 +42,7 @@ public class ForImmutability
   }
 
   [Fact]
-  public void AsSpanAndAsMemoryAreSame()
+  public static void AsSpanAndAsMemoryAreSame()
   {
     RecordCollection<string> collection = ["a", "b"];
 
@@ -54,7 +54,7 @@ public class ForImmutability
 
   [Theory]
   [ClassData(typeof(UnsupportedMethods))]
-  public void AndThrowForUnsupportedMethods(string name, Action action)
+  public static void AndThrowForUnsupportedMethods(string name, Action action)
   {
     action
       .Should()

--- a/Org.Grush.Lib.RecordCollections.Tests/ForImmutability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForImmutability.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using FluentAssertions;
@@ -49,6 +50,12 @@ public class ForImmutability
         ((ICollection<long>)collection).Remove,
         ((IList<long>)collection).Insert,
         ((IList<long>)collection).RemoveAt,
+        ((IList)collection).Clear,
+        ((IList)collection).RemoveAt,
+        ((IList)collection).Add,
+        ((ICollection)collection).CopyTo,
+        ((IList)collection).Insert,
+        ((IList)collection).Remove,
       };
 
       foreach (var fn in functions)
@@ -58,8 +65,9 @@ public class ForImmutability
           GetDefaultCallOfMethod(collection, fn.Method)
         );
       }
-      
+
       Add("RecordCollection<T>[0] =", (() => collection[0] = 0));
+      Add("((IList)RecordCollection<T>)[0] =", () => ((IList)collection)[0] = 0);
     }
   }
 

--- a/Org.Grush.Lib.RecordCollections.Tests/ForInitializability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForInitializability.cs
@@ -2,10 +2,10 @@ using FluentAssertions;
 
 namespace Org.Grush.Lib.RecordCollections.Tests;
 
-public class ForInitializability
+public static class ForInitializability
 {
   [Fact]
-  public void UsingEmptyCreate()
+  public static void UsingEmptyCreate()
   {
     // Act
     var coll = RecordCollection.Create<double>();
@@ -18,7 +18,7 @@ public class ForInitializability
   }
 
   [Fact]
-  public void UsingStaticCreateMethod()
+  public static void UsingStaticCreateMethod()
   {
     // Act
     var collection = RecordCollection.Create(["A", "B"]);
@@ -33,7 +33,7 @@ public class ForInitializability
   }
 
   [Fact]
-  public void UsingCollectionExpression()
+  public static void UsingCollectionExpression()
   {
     // Act
     RecordCollection<double> collection = [3.14159, double.NaN, double.PositiveInfinity];
@@ -49,7 +49,7 @@ public class ForInitializability
   }
 
   [Fact]
-  public void UsingEnumerableExtension()
+  public static void UsingEnumerableExtension()
   {
     // Assemble
     List<int> oldList = [1, 2, 3];
@@ -71,7 +71,7 @@ public class ForInitializability
   }
 
   [Fact]
-  public void UsingEnumerableExtension_ForReadOnlySpan()
+  public static void UsingEnumerableExtension_ForReadOnlySpan()
   {
     // Assemble
     ReadOnlySpan<string> span = ["a", "b", "c"];
@@ -88,7 +88,7 @@ public class ForInitializability
   }
 
   [Fact]
-  public void UsingCreateRange()
+  public static void UsingCreateRange()
   {
     // Assemble
     List<string> input = ["a", "b"];

--- a/Org.Grush.Lib.RecordCollections.Tests/ForInitializability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForInitializability.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using FluentAssertions;
 
 namespace Org.Grush.Lib.RecordCollections.Tests;
@@ -99,5 +100,59 @@ public static class ForInitializability
     collection
       .Should()
       .BeEquivalentTo(["a", "b"]);
+  }
+
+  public static class Conversions
+  {
+
+    [Fact]
+    public static void CastingFromImmutableArray()
+    {
+      ImmutableArray<string> input = ["a", "b"];
+      var collection = (RecordCollection<string>)input;
+      var castedBack = (ImmutableArray<string>)collection;
+
+      collection.Should().BeEquivalentTo(castedBack);
+      input.Should().NotBeSameAs(castedBack);
+    }
+
+    [Fact]
+    public static void CastUp()
+    {
+      RecordCollection<Sub> sub = [new(1, 10, 100), new(2, 20, 200)];
+
+      var super = RecordCollection<Super>.CastUp(sub);
+
+      super.Should().BeOfType<RecordCollection<Super>>();
+    }
+
+    [Fact]
+    public static void As_FailsOnBadCasts()
+    {
+      RecordCollection<Super> supes = [new(1, 100), new(2, 200)];
+
+      var act = () => supes.As<Sub>();
+
+      act.Should().Throw<InvalidCastException>();
+    }
+
+    [Fact]
+    public static void As_CanCastUp()
+    {
+      RecordCollection<Sub> subs = [new(1, 100, 10000), new(2, 200, 2000)];
+
+      var supers = subs.As<Super>();
+
+      supers
+        .Should()
+        .BeOfType<RecordCollection<Super>>();
+    }
+
+    record Super(int A, int B)
+    {
+      public static implicit operator List<int>(Super sub) => [sub.A, sub.B];
+    }
+
+    record Sub(int A, int B, int C) : Super(A, B);
   }
 }

--- a/Org.Grush.Lib.RecordCollections.Tests/ForLinqExtensions.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForLinqExtensions.cs
@@ -1,0 +1,144 @@
+using FluentAssertions;
+
+namespace Org.Grush.Lib.RecordCollections.Tests;
+
+public static class ForLinqExtensions
+{
+  private record class Super(int A, int B);
+  private record class Sub(int A, int B, int C, int D) : Super(A, B);
+
+  private class SuperEqualityComparer : IEqualityComparer<Super>
+  {
+    public bool Equals(Super? x, Super? y)
+    {
+      return
+        x?.A == y?.A &&
+        x?.B == y?.B;
+
+    }
+
+    public int GetHashCode(Super obj) => obj.GetHashCode();
+  }
+
+  [Fact]
+  public static void SequenceEqual_CompareBaseToDerived_WithComparer()
+  {
+    RecordCollection<Super> super = [new(1, 10), new(2, 20)];
+    RecordCollection<Sub> sub = [new(1, 10, 100, 1000), new(2, 20, 200, 2000)];
+
+    var eq = super.SequenceEqual(sub, new SuperEqualityComparer());
+
+    eq.Should().BeTrue();
+  }
+
+  [Fact]
+  public static void SequenceEqual_CompareBaseToDerivedEnumerable_WithComparer()
+  {
+    RecordCollection<Super> super = [new(1, 10), new(2, 20)];
+    IEnumerable<Sub> sub = Enumerable.Range(1, 2).Select(i => new Sub(i, i * 10, i* 100, i* 1000));
+
+    var eq = super.SequenceEqual(sub, new SuperEqualityComparer());
+
+    eq.Should().BeTrue();
+  }
+
+  [Fact]
+  public static void SequenceEqual_CompareBaseToDerived_WithFunction()
+  {
+    RecordCollection<Super> super = [new(1, 10), new(2, 20)];
+    RecordCollection<Sub> sub = [new(1, 10, 100, 1000), new(2, 20, 200, 2000)];
+
+    var eq = super.SequenceEqual(sub, (x, y) => x.A == y.A && x.B == y.B);
+
+    eq.Should().BeTrue();
+  }
+
+  [Fact]
+  public static void Select_ConfirmingLazy()
+  {
+    RecordCollection<int> ints = [1, 2, 3, 4];
+
+    int iterations = 0;
+    var enumerable = ints.Select(x =>
+    {
+      ++iterations;
+      return (long)x;
+    });
+
+    iterations.Should().Be(0);
+
+    enumerable
+      .Should()
+      .BeEquivalentTo([1L, 2L, 3L, 4L]);
+  }
+
+  [Fact]
+  public static void Where_ConfirmingLazy()
+  {
+    RecordCollection<int> ints = [1, 2, 3, 4];
+
+    int iterations = 0;
+    var enumerable = ints.Where(x =>
+    {
+      ++iterations;
+      return (x % 2) == 0;
+    });
+
+    iterations.Should().Be(0);
+
+    enumerable
+      .Should()
+      .BeEquivalentTo([2, 4]);
+  }
+
+  [Fact]
+  public static void ToDictionary_NoElementSelector()
+  {
+    var records = RecordCollection.Create([
+      new { key = 1 },
+      new { key = 2 },
+      new { key = 3 },
+    ]);
+
+    var dict = records.ToDictionary(obj => obj.key);
+
+    dict.Keys.Should().BeEquivalentTo([1, 2, 3]);
+  }
+
+  [Fact]
+  public static void ToDictionary()
+  {
+    var records = RecordCollection.Create([
+      new { key = 1, V = "A" },
+      new { key = 2, V = "B" },
+      new { key = 3, V = "C" },
+    ]);
+
+    var dict = records.ToDictionary(obj => obj.key, obj => obj.V);
+
+    dict
+      .Should()
+      .BeEquivalentTo(
+        new Dictionary<int, string>
+        {
+          { 1, "A" },
+          { 2, "B" },
+          { 3, "C" },
+        }
+      );
+  }
+
+  [Fact]
+  public static void ToArray()
+  {
+    RecordCollection<int> ints = [1, 2, 3, 4];
+
+    var array = ints.ToArray();
+
+    array
+      .Should()
+      .BeOfType<int[]>()
+      .And
+      .BeEquivalentTo(ints);
+  }
+}

--- a/Org.Grush.Lib.RecordCollections.Tests/ForSerializability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForSerializability.cs
@@ -9,11 +9,11 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 namespace Org.Grush.Lib.RecordCollections.Tests;
 
 [SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters")]
-public class ForSerializability
+public static class ForSerializability
 {
   [Theory]
   [ClassData(typeof(Serializers))]
-  public void WithMultipleLayers(string name,
+  public static void WithMultipleLayers(string name,
     Func<TestRecord<RecordCollection<int>, RecordCollection<string>>, string> serializer)
   {
     var result = serializer(
@@ -33,7 +33,7 @@ public class ForSerializability
   }
 
   [Fact]
-  public void WithNonstandardSettings()
+  public static void WithNonstandardSettings()
   {
     var result = JsonSerializer.Serialize(
       [
@@ -53,8 +53,7 @@ public class ForSerializability
           """);
   }
 
-  private class
-    Serializers : TheoryData<string, Func<TestRecord<RecordCollection<int>, RecordCollection<string>>, string>>
+  private class Serializers : TheoryData<string, Func<TestRecord<RecordCollection<int>, RecordCollection<string>>, string>>
   {
     public Serializers()
     {

--- a/Org.Grush.Lib.RecordCollections.Tests/ForSerializability.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ForSerializability.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using FluentAssertions;
+using Moq;
 using Newtonsoft.Json;
 using Org.Grush.Lib.RecordCollections.Newtonsoft;
 using Org.Grush.Lib.RecordCollections.Tests.Utilities;
@@ -55,17 +56,70 @@ public static class ForSerializability
           """);
   }
 
+  [Theory]
+  [InlineData(true)]
+  [InlineData(false)]
+  public static void NewtonsoftWithConverterCacheIsEnabled(bool enabled)
+  {
+    var genericCollectionOf = typeof(int);
+
+    var mockType = new Mock<Type>(MockBehavior.Strict);
+    mockType.Setup(m => m.GetGenericArguments()).Returns([genericCollectionOf]);
+    mockType.Setup(m => m.GetHashCode()).Returns(1);
+    mockType.Setup(m => m.ToString()).Returns("_.Mock.Type");
+    mockType.Setup(m => m.Equals(It.IsAny<object>())).Returns((object v) => ReferenceEquals(v, mockType.Object));
+
+    NewtonsoftJsonSerializer serializer = new();
+
+    var factory = new RecordCollectionNewtonsoftJsonConverterFactory(useConverterCache: enabled);
+
+    factory.ReadJson(CreateReaderMock().Object, mockType.Object, null, serializer);
+    factory.ReadJson(CreateReaderMock().Object, mockType.Object, null, serializer);
+
+    mockType.Verify(m => m.GetGenericArguments(), enabled ? Times.Once() : Times.Exactly(2));
+
+    return;
+
+    static Mock<JsonReader> CreateReaderMock()
+    {
+      var mockReader = new Mock<JsonReader>(MockBehavior.Strict);
+      List <(JsonToken Token, string Path, int Depth)> sequence =
+      [
+        (JsonToken.StartArray, "$.Start", 0),
+        (JsonToken.EndArray, "$.End", 1),
+      ];
+      using var enumerator = sequence.GetEnumerator();
+
+      mockReader.Setup(r => r.Read()).Returns(() => enumerator.MoveNext());
+      mockReader.SetupGet(r => r.Path).Returns(() => enumerator.Current.Path);
+      mockReader.SetupGet(r => r.TokenType).Returns(() => enumerator.Current.Token);
+      mockReader.SetupGet(r => r.Depth).Returns(() => enumerator.Current.Depth);
+      mockReader.Setup(r => r.ReadAsInt32()).Returns(() =>
+      {
+        enumerator.MoveNext();
+        return null;
+      });
+
+      return mockReader;
+    }
+  }
+
+
   public static class ForcedEdgeCases
   {
-    [Fact]
-    public static void TryingToWriteWithNewtonsoftThrows()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public static void TryingToWriteWithNewtonsoftThrows(bool useFactory)
     {
       // Assemble
       JsonWriter writer = new JsonTextWriter(new StringWriter());
       RecordCollection<int> data = [1, 2, 3];
       NewtonsoftJsonSerializer serializer = new();
 
-      RecordCollectionNewtonsoftJsonConverter<int> converter = new();
+      JsonConverter converter = useFactory
+        ? new RecordCollectionNewtonsoftJsonConverterFactory()
+        : new RecordCollectionNewtonsoftJsonConverter<int>();
 
       // Act/Assert
       var action = () => converter.WriteJson(writer, data, serializer);

--- a/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_ImmutableList.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_ImmutableList.cs
@@ -1,0 +1,393 @@
+using FluentAssertions;
+using System.Collections.Immutable;
+
+namespace Org.Grush.Lib.RecordCollections.Tests.ImplementationOf;
+
+/// <summary>
+/// Yes these methods are mostly actually testing the <see cref="ImmutableArray{T}"/>
+/// struct but the intent is to make sure we're correctly interacting with that struct.
+/// </summary>
+public class Interface_ImmutableList
+{
+  public class ImplicitImplementations
+  {
+    private class StartsWithComparer : IEqualityComparer<string>
+    {
+      public bool Equals(string? ofStr, string? first)
+      {
+        if (first is null || ofStr is null)
+          return false;
+
+        return ofStr.StartsWith(first);
+      }
+
+      public int GetHashCode(string obj) => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void IndexOf()
+    {
+      RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
+
+      var foundIndex = collection.IndexOf("c");
+
+      foundIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public void IndexOf_IndexCount()
+    {
+      RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
+
+      var foundIndex = collection.IndexOf(item: "a", index: 2, count: 4);
+
+      foundIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void IndexOf_WithComparer()
+    {
+      RecordCollection<string> collection = ["Ayo", "Bye", "Cool", "And", "Bots", "Craze"];
+
+      var foundIndex = collection.IndexOf(item: "A", index: 2, count: 4, new StartsWithComparer());
+
+      foundIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void IndexOf_Missing()
+    {
+      RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
+
+      var foundIndex = collection.IndexOf(item: "a", index: 1, count: 2);
+
+      foundIndex.Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOf()
+    {
+      RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
+
+      var foundIndex = collection.LastIndexOf("a");
+
+      foundIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOf_IndexCount()
+    {
+      RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c", "a", "b", "c"];
+
+      var foundIndex = collection.LastIndexOf(item: "a", index: 5, count: 5);
+
+      foundIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOf_WithComparer()
+    {
+      RecordCollection<string> collection = ["Ayo", "Bye", "Cool", "And", "Bots", "Craze", "Are", "Bits"];
+
+      var foundIndex = collection.IndexOf(item: "A", index: 1, count: 5, new StartsWithComparer());
+
+      foundIndex.Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOf_Missing()
+    {
+      RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
+
+      var foundIndex = collection.IndexOf(item: "a", index: 1, count: 2);
+
+      foundIndex.Should().Be(-1);
+    }
+  }
+
+  public class ExplicitImplementations
+  {
+    private const int InitialLength = 6;
+    private static readonly RecordCollection<int> Initial = [1, 2, 3, 4, 5, 6];
+    private static IImmutableList<int> InitialAsList => Initial;
+
+    [Fact]
+    public void Add()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.Add(10);
+      var result = Initial.Add(10);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 3, 4, 5, 6, 10]);
+    }
+
+    [Fact]
+    public void AddRange()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.AddRange([10, 11, 12]);
+      var result = Initial.AddRange([10, 11, 12]);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 3, 4, 5, 6, 10, 11, 12]);
+    }
+
+    [Fact]
+    public void Clear()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.Clear();
+      var result = Initial.Clear();
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEmpty();
+    }
+
+    [Fact]
+    public void Insert()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.Insert(3, 10);
+      var result = Initial.Insert(3, 10);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 3, 10, 4, 5, 6]);
+    }
+
+    [Fact]
+    public void InsertRange()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.InsertRange(3, [10, 11, 12]);
+      var result = Initial.InsertRange(3, [10, 11, 12]);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 3, 10, 11, 12, 4, 5, 6]);
+    }
+
+    /// <summary>"Matches" any time `x` parameter is even.</summary>
+    private class EvenEqualityComparer : IEqualityComparer<int>
+    {
+      public bool Equals(int x, int y)
+      {
+        return x % 2 is 0;
+      }
+
+      public int GetHashCode(int obj)
+        => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void Remove_WithComparer()
+    {
+      RecordCollection<int> duplicatingCollection = [1, 2, 3, 4, 5, 6];
+      IImmutableList<int> duplicatingCollectionAsList = duplicatingCollection;
+
+      var resultAsList = duplicatingCollectionAsList.Remove(999, new EvenEqualityComparer());
+
+      duplicatingCollection.Count.Should().Be(6);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, /* 2 removed */3, 4, 5, 6]);
+    }
+
+    [Fact]
+    public void Remove_WithoutComparer()
+    {
+      RecordCollection<int> duplicatingCollection = [1, 2, 2, 2, 2, 3];
+      IImmutableList<int> duplicatingCollectionAsList = duplicatingCollection;
+
+      var resultAsList = duplicatingCollectionAsList.Remove(2, null);
+
+      duplicatingCollection.Count.Should().Be(6);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, /* single removed */2, 2, 2, 3]);
+    }
+
+    [Fact]
+    public void RemoveAll()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.RemoveAll(i => i % 2 is 0);
+      var result = Initial.RemoveAll(i => i % 2 is 0);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 3, 5,]);
+    }
+
+    [Fact]
+    public void RemoveAt()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.RemoveAt(3);
+      var result = Initial.RemoveAt(3);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 3, /* removed */ 5, 6]);
+    }
+
+    [Fact]
+    public void RemoveRange_WithoutComparer()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.RemoveRange([3, 4, 5], null);
+      var result = Initial.RemoveRange([3, 4, 5]);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, /* removed */6]);
+    }
+
+    [Fact]
+    public void RemoveRange_WithComparer()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.RemoveRange([999, 999], new EvenEqualityComparer());
+      var result = Initial.RemoveRange([999, 999], new EvenEqualityComparer());
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, /* removed */3, /* removed */5, 6]);
+    }
+
+    [Fact]
+    public void RemoveRange_IndexCount()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.RemoveRange(2, 3);
+      var result = Initial.RemoveRange(2, 3);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, /* removed */6]);
+    }
+
+    [Fact]
+    public void Replace_WithComparer()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.Replace(999, 10, new EvenEqualityComparer());
+      var result = Initial.Replace(999, 10, new EvenEqualityComparer());
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 10, 3, 4, 5, 6]);
+    }
+
+    [Fact]
+    public void Replace_WithoutComparer()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.Replace(3, 10, null);
+      var result = Initial.Replace(3, 10);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 10, 4, 5, 6]);
+    }
+
+    [Fact]
+    public void SetItem()
+    {
+      var initialAsList = InitialAsList;
+
+      var resultAsList = initialAsList.SetItem(3, 10);
+      var result = Initial.SetItem(3, 10);
+
+      result.Should().Equal(resultAsList);
+
+      initialAsList.Count.Should().Be(InitialLength);
+      initialAsList.Count.Should().Be(InitialLength);
+      resultAsList
+        .Should()
+        .BeOfType<RecordCollection<int>>()
+        .And
+        .BeEquivalentTo([1, 2, 3, 10, 5, 6]);
+    }
+  }
+}

--- a/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_ImmutableList.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_ImmutableList.cs
@@ -7,9 +7,9 @@ namespace Org.Grush.Lib.RecordCollections.Tests.ImplementationOf;
 /// Yes these methods are mostly actually testing the <see cref="ImmutableArray{T}"/>
 /// struct but the intent is to make sure we're correctly interacting with that struct.
 /// </summary>
-public class Interface_ImmutableList
+public static class Interface_ImmutableList
 {
-  public class ImplicitImplementations
+  public static class ImplicitImplementations
   {
     private class StartsWithComparer : IEqualityComparer<string>
     {
@@ -25,7 +25,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void IndexOf()
+    public static void IndexOf()
     {
       RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
 
@@ -35,7 +35,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void IndexOf_IndexCount()
+    public static void IndexOf_IndexCount()
     {
       RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
 
@@ -45,7 +45,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void IndexOf_WithComparer()
+    public static void IndexOf_WithComparer()
     {
       RecordCollection<string> collection = ["Ayo", "Bye", "Cool", "And", "Bots", "Craze"];
 
@@ -55,7 +55,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void IndexOf_Missing()
+    public static void IndexOf_Missing()
     {
       RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
 
@@ -65,7 +65,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void LastIndexOf()
+    public static void LastIndexOf()
     {
       RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
 
@@ -75,7 +75,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void LastIndexOf_IndexCount()
+    public static void LastIndexOf_IndexCount()
     {
       RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c", "a", "b", "c"];
 
@@ -85,7 +85,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void LastIndexOf_WithComparer()
+    public static void LastIndexOf_WithComparer()
     {
       RecordCollection<string> collection = ["Ayo", "Bye", "Cool", "And", "Bots", "Craze", "Are", "Bits"];
 
@@ -95,7 +95,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void LastIndexOf_Missing()
+    public static void LastIndexOf_Missing()
     {
       RecordCollection<string> collection = ["a", "b", "c", "a", "b", "c"];
 
@@ -105,14 +105,14 @@ public class Interface_ImmutableList
     }
   }
 
-  public class ExplicitImplementations
+  public static class ExplicitImplementations
   {
     private const int InitialLength = 6;
     private static readonly RecordCollection<int> Initial = [1, 2, 3, 4, 5, 6];
     private static IImmutableList<int> InitialAsList => Initial;
 
     [Fact]
-    public void Add()
+    public static void Add()
     {
       var initialAsList = InitialAsList;
 
@@ -130,7 +130,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void AddRange()
+    public static void AddRange()
     {
       var initialAsList = InitialAsList;
 
@@ -148,7 +148,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void Clear()
+    public static void Clear()
     {
       var initialAsList = InitialAsList;
 
@@ -166,7 +166,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void Insert()
+    public static void Insert()
     {
       var initialAsList = InitialAsList;
 
@@ -184,7 +184,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void InsertRange()
+    public static void InsertRange()
     {
       var initialAsList = InitialAsList;
 
@@ -214,7 +214,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void Remove_WithComparer()
+    public static void Remove_WithComparer()
     {
       RecordCollection<int> duplicatingCollection = [1, 2, 3, 4, 5, 6];
       IImmutableList<int> duplicatingCollectionAsList = duplicatingCollection;
@@ -230,7 +230,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void Remove_WithoutComparer()
+    public static void Remove_WithoutComparer()
     {
       RecordCollection<int> duplicatingCollection = [1, 2, 2, 2, 2, 3];
       IImmutableList<int> duplicatingCollectionAsList = duplicatingCollection;
@@ -246,7 +246,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void RemoveAll()
+    public static void RemoveAll()
     {
       var initialAsList = InitialAsList;
 
@@ -264,7 +264,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void RemoveAt()
+    public static void RemoveAt()
     {
       var initialAsList = InitialAsList;
 
@@ -282,7 +282,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void RemoveRange_WithoutComparer()
+    public static void RemoveRange_WithoutComparer()
     {
       var initialAsList = InitialAsList;
 
@@ -300,7 +300,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void RemoveRange_WithComparer()
+    public static void RemoveRange_WithComparer()
     {
       var initialAsList = InitialAsList;
 
@@ -318,7 +318,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void RemoveRange_IndexCount()
+    public static void RemoveRange_IndexCount()
     {
       var initialAsList = InitialAsList;
 
@@ -336,7 +336,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void Replace_WithComparer()
+    public static void Replace_WithComparer()
     {
       var initialAsList = InitialAsList;
 
@@ -354,7 +354,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void Replace_WithoutComparer()
+    public static void Replace_WithoutComparer()
     {
       var initialAsList = InitialAsList;
 
@@ -372,7 +372,7 @@ public class Interface_ImmutableList
     }
 
     [Fact]
-    public void SetItem()
+    public static void SetItem()
     {
       var initialAsList = InitialAsList;
 

--- a/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_List.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_List.cs
@@ -3,14 +3,14 @@ using FluentAssertions;
 
 namespace Org.Grush.Lib.RecordCollections.Tests.ImplementationOf;
 
-public class Interface_List
+public static class Interface_List
 {
-  public class Generic
+  public static class Generic
   {
     record SomeRecord(int Int, string String);
 
     [Fact]
-    public void IndexOf()
+    public static void IndexOf()
     {
       RecordCollection<SomeRecord> collection =
       [
@@ -26,7 +26,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void Contains()
+    public static void Contains()
     {
       RecordCollection<SomeRecord> collection =
       [
@@ -42,7 +42,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void CopyTo_Span()
+    public static void CopyTo_Span()
     {
       RecordCollection<string> collection = ["a", "b", "c"];
       var targetSpan = new Span<string>(new string[3]);
@@ -56,13 +56,13 @@ public class Interface_List
     }
   }
 
-  public class NonGeneric
+  public static class NonGeneric
   {
     static readonly RecordCollection<string> collection = ["a", "b", "c"];
     static IList CollectionAsIList => collection;
 
     [Fact]
-    public void GetByIndex()
+    public static void GetByIndex()
     {
       object? item1 = CollectionAsIList[1];
 
@@ -70,7 +70,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void Contains()
+    public static void Contains()
     {
       var contains = CollectionAsIList.Contains("b");
 
@@ -78,7 +78,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void Contains_FalseWhenMissing()
+    public static void Contains_FalseWhenMissing()
     {
       var contains = CollectionAsIList.Contains("Z");
 
@@ -86,7 +86,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void Contains_FalseForWrongType()
+    public static void Contains_FalseForWrongType()
     {
       var contains = CollectionAsIList.Contains(CollectionAsIList);
 
@@ -94,7 +94,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void IndexOf()
+    public static void IndexOf()
     {
       int foundIndex = CollectionAsIList.IndexOf("b");
 
@@ -102,7 +102,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void IndexOf_Negative1WhenMissing()
+    public static void IndexOf_Negative1WhenMissing()
     {
       int foundIndex = CollectionAsIList.IndexOf("Z");
 
@@ -110,7 +110,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void IndexOf_Negative1WhenMissingNull()
+    public static void IndexOf_Negative1WhenMissingNull()
     {
       int foundIndex = CollectionAsIList.IndexOf(null);
 
@@ -118,7 +118,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void IndexOf_Negative1ForWrongType()
+    public static void IndexOf_Negative1ForWrongType()
     {
       int foundIndex = CollectionAsIList.IndexOf(CollectionAsIList);
 
@@ -126,7 +126,7 @@ public class Interface_List
     }
 
     [Fact]
-    public void ConstantProperties()
+    public static void ConstantProperties()
     {
       CollectionAsIList.IsFixedSize.Should().BeTrue();
       CollectionAsIList.IsReadOnly.Should().BeTrue();

--- a/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_List.cs
+++ b/Org.Grush.Lib.RecordCollections.Tests/ImplementationOf/Interface_List.cs
@@ -1,0 +1,140 @@
+using System.Collections;
+using FluentAssertions;
+
+namespace Org.Grush.Lib.RecordCollections.Tests.ImplementationOf;
+
+public class Interface_List
+{
+  public class Generic
+  {
+    record SomeRecord(int Int, string String);
+
+    [Fact]
+    public void IndexOf()
+    {
+      RecordCollection<SomeRecord> collection =
+      [
+        new(1, "A"),
+        new(2, "B"),
+        new(2, "B"),
+        new(2, "b"),
+      ];
+
+      var foundIndex = collection.IndexOf(new SomeRecord(2, "B"));
+
+      foundIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void Contains()
+    {
+      RecordCollection<SomeRecord> collection =
+      [
+        new(1, "A"),
+        new(2, "B"),
+        new(2, "B"),
+        new(2, "b"),
+      ];
+
+      var foundIndex = collection.Contains(new SomeRecord(2, "B"));
+
+      foundIndex.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CopyTo_Span()
+    {
+      RecordCollection<string> collection = ["a", "b", "c"];
+      var targetSpan = new Span<string>(new string[3]);
+
+      collection.CopyTo(targetSpan);
+
+      targetSpan[0].Should().Be("a");
+      targetSpan[1].Should().Be("b");
+      targetSpan[2].Should().Be("c");
+      targetSpan.Length.Should().Be(3);
+    }
+  }
+
+  public class NonGeneric
+  {
+    static readonly RecordCollection<string> collection = ["a", "b", "c"];
+    static IList CollectionAsIList => collection;
+
+    [Fact]
+    public void GetByIndex()
+    {
+      object? item1 = CollectionAsIList[1];
+
+      item1.Should().Be("b");
+    }
+
+    [Fact]
+    public void Contains()
+    {
+      var contains = CollectionAsIList.Contains("b");
+
+      contains.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Contains_FalseWhenMissing()
+    {
+      var contains = CollectionAsIList.Contains("Z");
+
+      contains.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contains_FalseForWrongType()
+    {
+      var contains = CollectionAsIList.Contains(CollectionAsIList);
+
+      contains.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IndexOf()
+    {
+      int foundIndex = CollectionAsIList.IndexOf("b");
+
+      foundIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void IndexOf_Negative1WhenMissing()
+    {
+      int foundIndex = CollectionAsIList.IndexOf("Z");
+
+      foundIndex.Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOf_Negative1WhenMissingNull()
+    {
+      int foundIndex = CollectionAsIList.IndexOf(null);
+
+      foundIndex.Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOf_Negative1ForWrongType()
+    {
+      int foundIndex = CollectionAsIList.IndexOf(CollectionAsIList);
+
+      foundIndex.Should().Be(-1);
+    }
+
+    [Fact]
+    public void ConstantProperties()
+    {
+      CollectionAsIList.IsFixedSize.Should().BeTrue();
+      CollectionAsIList.IsReadOnly.Should().BeTrue();
+      CollectionAsIList.IsSynchronized.Should().BeTrue();
+
+      var getSyncRoot = () => CollectionAsIList.SyncRoot;
+
+      getSyncRoot.Should().ThrowExactly<NotSupportedException>();
+    }
+  }
+}

--- a/Org.Grush.Lib.RecordCollections.Tests/Org.Grush.Lib.RecordCollections.Tests.csproj
+++ b/Org.Grush.Lib.RecordCollections.Tests/Org.Grush.Lib.RecordCollections.Tests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>true</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Org.Grush.Lib.RecordCollections.Tests/Org.Grush.Lib.RecordCollections.Tests.csproj
+++ b/Org.Grush.Lib.RecordCollections.Tests/Org.Grush.Lib.RecordCollections.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageReference Include="xunit" Version="2.5.3"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Org.Grush.Lib.RecordCollections.Tests/run-tests.sh
+++ b/Org.Grush.Lib.RecordCollections.Tests/run-tests.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+thisDir="$(dirname "$0")"
+testResultsDir="./TestResults"
+
+cd $thisDir
+
+sect="==============================="
+
+echo "Clean up existing tests"
+rm -rf "$testResultsDir"
+
+echo $sect
+
+echo "Run tests with coverage"
+dotnet test --collect:"XPlat Code Coverage"
+testStatus=$?
+
+if (( testStatus > 0 )); then
+  echo "ERROR: Failed tests"
+  cd -
+  exit $testStatus
+fi
+
+echo $sect
+
+
+echo "Running tests..."
+dotnet tool restore && \
+  dotnet reportgenerator -reports:"$(find "$testResultsDir"/*/coverage.cobertura.xml)" -targetdir:coveragereport
+
+reportResult=$?
+
+if (( reportResult > 0 )); then
+  echo "ERROR: Reporting failed"
+  cd -
+fi
+
+#grepResult=$(
+#  grep -onE '<coverage line-rate="(.+?)" branch-rate="(.+?)"'  "$testResultsDir"/*/coverage.cobertura.xml
+#)
+#
+#if [[ "$grepResult" != '2:<coverage line-rate="1" branch-rate="1"' ]]; then
+#  echo "ERROR: code coverage regression: $grepResult"
+#  cd -
+#  exit 99
+#fi
+#
+#echo "Success, perfect coverage."
+#
+#cd -
+
+exit 0

--- a/Org.Grush.Lib.RecordCollections/README.md
+++ b/Org.Grush.Lib.RecordCollections/README.md
@@ -158,7 +158,6 @@ and supports the collection builder syntax.
 .NET Standard 2.1 version requires two System NuGet packages, `System.Collections.Immutable` and `System.Text.Json`,
 but supports .NET 5–7.
 
-.NET Standard 2.0 version requires the above System NuGet packages,
+.NET Standard 2.0 version requires the above System NuGet packages and also the `Microsoft.Bcl.HashCode` NuGet package,
 loses some nullability checks,
-and internally uses a shim for the `HashCode` struct,
 but supports a significantly broader set of .NET versions including 4.6.1–4.8, Mono 5.4, and UWP.

--- a/Org.Grush.Lib.RecordCollections/README.md
+++ b/Org.Grush.Lib.RecordCollections/README.md
@@ -74,12 +74,12 @@ contains.Should().BeTrue();
 1. Calls to `RecordCollection<T>#Equals(object)` or `RecordCollection<T>#Equals(object, IEqualityComparer<T>)` are only supported for other `RecordCollection<T>`.
 2. Explicit calls to `((IStructuralEquatable)RecordCollection<T>)#Equals(object?, IEqualityComparer)`
 follow a priority order for checking:
-   1. if the comparer implements `IEqualityComparer<T>` and the other is `<T>`, optimized `SequenceEqual` is used.
-   2. if other implements `IStructuralEquatable`, we call `#GetHashCode(comparer)` on each instance and compare.
-   3. if other implements `IEnumerable<T>`:
+   1. if other implements `IEnumerable<T>`:
       * if other implements `IReadOnlyCollection<TOther>`, we check that counts match.
       * if other implements `IReadOnlyList<TOther>`, an index-optimized `SequenceEqual` is used.
       * otherwise, we iteratively check each index.
+   2. if the comparer implements `IEqualityComparer<T>` and the other is `<T>`, optimized `SequenceEqual` is used.
+   3. if other implements `IStructuralEquatable`, we call `#GetHashCode(comparer)` on each instance and compare.
    4. if other implements `IEnumerable`, a de-optimized `SequenceEqual` is used.
 
 ## Serialization

--- a/Org.Grush.Lib.RecordCollections/README.md
+++ b/Org.Grush.Lib.RecordCollections/README.md
@@ -113,6 +113,9 @@ Newtonsoft deserialization is supported using the supplementary `Org.Grush.Lib.R
 either with the generic `RecordCollectionNewtonsoftJsonConverterFactory`,
 or if a specific type is known then `RecordCollectionNewtonsoftJsonConverter<T>` converter can be used directly.
 
+See the [NuGet package](https://www.nuget.org/packages/Org.Grush.Lib.RecordCollections.Newtonsoft)
+or the [GitHub source](https://github.com/skgrush/Org.Grush.Lib.RecordCollections/tree/main/Org.Grush.Lib.RecordCollections.Newtonsoft).
+
 ```cs
 using Newtonsoft.Json;
 using Org.Grush.Lib.RecordCollections.Newtonsoft;

--- a/Org.Grush.Lib.RecordCollections/README.md
+++ b/Org.Grush.Lib.RecordCollections/README.md
@@ -52,8 +52,10 @@ MyRecord a = new("Joseph", ["Joe", "Joey"]);
 MyRecord b = new("Joseph", ["Joe", "Joey"]);
 
 var areEqual = a.Equals(b);
+var areEqualsSign = a == b;
 
 areEqual.Should().BeTrue();
+areEqualsSign.Should().BeTrue();
 ```
 
 additionally, `RecordCollection<T>`s can be used in hash structures like `HashSet`s:

--- a/Org.Grush.Lib.RecordCollections/README.md
+++ b/Org.Grush.Lib.RecordCollections/README.md
@@ -74,13 +74,11 @@ contains.Should().BeTrue();
 1. Calls to `RecordCollection<T>#Equals(object)` or `RecordCollection<T>#Equals(object, IEqualityComparer<T>)` are only supported for other `RecordCollection<T>`.
 2. Explicit calls to `((IStructuralEquatable)RecordCollection<T>)#Equals(object?, IEqualityComparer)`
 follow a priority order for checking:
-   1. if other implements `IEnumerable<T>`:
-      * if other implements `IReadOnlyCollection<TOther>`, we check that counts match.
-      * if other implements `IReadOnlyList<TOther>`, an index-optimized `SequenceEqual` is used.
-      * otherwise, we iteratively check each index.
-   2. if the comparer implements `IEqualityComparer<T>` and the other is `<T>`, optimized `SequenceEqual` is used.
-   3. if other implements `IStructuralEquatable`, we call `#GetHashCode(comparer)` on each instance and compare.
-   4. if other implements `IEnumerable`, a de-optimized `SequenceEqual` is used.
+   1. if other implements `IEnumerable<T>` AND comparer implements `IEqualityComparer<T>`,
+      we run a check using the `<T>`-typed equality comparison.
+   2. if other implements `IEnumerable` not `<T>`, a de-optimized `SequenceEqual` is used.
+   3. if other implements `IStructuralEquatable`, we call `#GetHashCode(comparer)` on each instance and compare;
+      **NOTE: this eagerly evaluates the entire sequence**.
 
 ## Serialization
 

--- a/Org.Grush.Lib.RecordCollections/README.md
+++ b/Org.Grush.Lib.RecordCollections/README.md
@@ -70,6 +70,18 @@ var contains = set.Contains([1.1, 2.2]);
 contains.Should().BeTrue();
 ```
 
+**`Equals` rules:**
+1. Calls to `RecordCollection<T>#Equals(object)` or `RecordCollection<T>#Equals(object, IEqualityComparer<T>)` are only supported for other `RecordCollection<T>`.
+2. Explicit calls to `((IStructuralEquatable)RecordCollection<T>)#Equals(object?, IEqualityComparer)`
+follow a priority order for checking:
+   1. if the comparer implements `IEqualityComparer<T>` and the other is `<T>`, optimized `SequenceEqual` is used.
+   2. if other implements `IStructuralEquatable`, we call `#GetHashCode(comparer)` on each instance and compare.
+   3. if other implements `IEnumerable<T>`:
+      * if other implements `IReadOnlyCollection<TOther>`, we check that counts match.
+      * if other implements `IReadOnlyList<TOther>`, an index-optimized `SequenceEqual` is used.
+      * otherwise, we iteratively check each index.
+   4. if other implements `IEnumerable`, a de-optimized `SequenceEqual` is used.
+
 ## Serialization
 
 Serialization is implicitly supported by both System.Text.Json and Newtonsoft.

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -278,7 +278,7 @@ public readonly struct RecordCollection<T> :
   /// Sequence equality check for an enumerable sequence of unknown type.
   /// </summary>
   [Pure]
-  public bool SequenceEqual(IEnumerable otherEnumerable, IEqualityComparer comparer)
+  public bool UntypedSequenceEqual(IEnumerable otherEnumerable, IEqualityComparer comparer)
   {
     int count = Count;
     if (otherEnumerable is ICollection list && count != list.Count)
@@ -323,7 +323,7 @@ public readonly struct RecordCollection<T> :
       return ((IStructuralEquatable)_data).Equals(ir.InnerData, comparer);
 
     if (other is IEnumerable enumerable)
-      return SequenceEqual(enumerable, comparer);
+      return UntypedSequenceEqual(enumerable, comparer);
 
     if (other is IStructuralEquatable equatable)
       return ((IStructuralEquatable)this).GetHashCode(comparer) == equatable.GetHashCode(comparer);

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Text.Json.Serialization;
 #if !NETSTANDARD2_0
 using System.Diagnostics.CodeAnalysis;
@@ -44,7 +45,9 @@ public readonly struct RecordCollection<T> :
   public static implicit operator RecordCollection<T>(ImmutableArray<T> data) => new(data: data);
   public static explicit operator ImmutableArray<T>(RecordCollection<T> r) => r._data;
 
+  [Pure]
   public ReadOnlySpan<T> AsSpan() => _data.AsSpan();
+  [Pure]
   public ReadOnlyMemory<T> AsMemory() => _data.AsMemory();
 
   public static bool operator==(RecordCollection<T> a, RecordCollection<T> b) => a.Equals(b);
@@ -53,6 +56,7 @@ public readonly struct RecordCollection<T> :
   public static bool operator!=(RecordCollection<T>? a, RecordCollection<T>? b) => !Equals(a, b);
 
   /// <summary>true if-and-only-if the collection is empty.</summary>
+  [Pure]
   public bool IsEmpty => _data.IsEmpty;
   [DebuggerBrowsable(DebuggerBrowsableState.Never)]
   bool IList.IsFixedSize => true;
@@ -61,6 +65,7 @@ public readonly struct RecordCollection<T> :
   [DebuggerBrowsable(DebuggerBrowsableState.Never)]
   bool IList.IsReadOnly => true;
   /// <summary>Number of elements in the collection.</summary>
+  [Pure]
   public int Count => _data.Length;
 
   bool ICollection.IsSynchronized => true;
@@ -75,8 +80,10 @@ public readonly struct RecordCollection<T> :
     set => throw new NotSupportedException(ExceptionMessage.Immutable);
   }
 
+  [Pure]
   public ref readonly T ItemRef(int index) => ref _data.ItemRef(index);
 
+  [Pure]
   public ImmutableArray<T>.Enumerator GetEnumerator() => _data.GetEnumerator();
   IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)_data).GetEnumerator();
   IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<T>)_data).GetEnumerator();
@@ -84,58 +91,72 @@ public readonly struct RecordCollection<T> :
   #region IImmutableList implementation overrides
 
   /// <inheritdoc cref="IImmutableList{T}.Add"/>
+  [Pure]
   public RecordCollection<T> Add(T value) => _data.Add(value);
 
   /// <inheritdoc cref="IImmutableList{T}.AddRange"/>
+  [Pure]
   public RecordCollection<T> AddRange(IEnumerable<T> items)
     => _data.AddRange(items);
 
   /// <summary>Creates a new empty list of the same type.</summary>
+  [Pure]
   public RecordCollection<T> Clear()
     => Empty;
 
   /// <inheritdoc cref="IImmutableList{T}.Insert"/>
+  [Pure]
   public RecordCollection<T> Insert(int index, T element)
     => _data.Insert(index, element);
 
   /// <inheritdoc cref="IImmutableList{T}.InsertRange"/>
+  [Pure]
   public RecordCollection<T> InsertRange(int index, IEnumerable<T> items)
     => _data.InsertRange(index, items);
 
   /// <inheritdoc cref="IImmutableList{T}.Remove"/>
-  public RecordCollection<T> Remove(T value, IEqualityComparer<T>? equalityComparer) =>
+  [Pure]
+  public RecordCollection<T> Remove(T value, IEqualityComparer<T>? equalityComparer = null) =>
     _data.Remove(value, equalityComparer);
 
   /// <inheritdoc cref="IImmutableList{T}.RemoveAll"/>
+  [Pure]
   public RecordCollection<T> RemoveAll(Predicate<T> match)
     => _data.RemoveAll(match);
 
   /// <inheritdoc cref="IImmutableList{T}.RemoveAt"/>
+  [Pure]
   public RecordCollection<T> RemoveAt(int index)
     => _data.RemoveAt(index);
 
   /// <inheritdoc cref="IImmutableList{T}.RemoveRange(System.Collections.Generic.IEnumerable{T},System.Collections.Generic.IEqualityComparer{T}?)"/>
-  public RecordCollection<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer) =>
+  [Pure]
+  public RecordCollection<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer = null) =>
     _data.RemoveRange(items, equalityComparer);
 
   /// <inheritdoc cref="IImmutableList{T}.RemoveRange(int,int)"/>
+  [Pure]
   public RecordCollection<T> RemoveRange(int index, int count)
     => _data.RemoveRange(index, count);
 
   /// <inheritdoc cref="IImmutableList{T}.Replace"/>
-  public RecordCollection<T> Replace(T oldValue, T newValue, IEqualityComparer<T>? equalityComparer) =>
+  [Pure]
+  public RecordCollection<T> Replace(T oldValue, T newValue, IEqualityComparer<T>? equalityComparer = null) =>
     _data.Replace(oldValue, newValue, equalityComparer);
 
   /// <inheritdoc cref="IImmutableList{T}.SetItem"/>
+  [Pure]
   public RecordCollection<T> SetItem(int index, T value)
     => _data.SetItem(index, value);
 
   /// <inheritdoc cref="IImmutableList{T}.IndexOf"/>
-  public int IndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
+  [Pure]
+  public int IndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer = null)
     => _data.IndexOf(item, index, count, equalityComparer);
 
   /// <inheritdoc cref="IImmutableList{T}.LastIndexOf"/>
-  public int LastIndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer)
+  [Pure]
+  public int LastIndexOf(T item, int index, int count, IEqualityComparer<T>? equalityComparer = null)
     => _data.LastIndexOf(item, index, count, equalityComparer);
 
   #endregion IImmutableList implementation overrides
@@ -147,8 +168,10 @@ public readonly struct RecordCollection<T> :
   void IList<T>.Insert(int index, T item) => throw new NotSupportedException(ExceptionMessage.Immutable);
   void IList<T>.RemoveAt(int index) => throw new NotSupportedException(ExceptionMessage.Immutable);
   /// <inheritdoc cref="IList{T}.IndexOf"/>
+  [Pure]
   public int IndexOf(T item) => _data.IndexOf(item);
   /// <inheritdoc cref="ICollection{T}.Contains"/>
+  [Pure]
   public bool Contains(T item) => _data.Contains(item);
   /// <inheritdoc cref="ImmutableArray{T}.CopyTo(T[],int)"/>
   public void CopyTo(T[] array, int arrayIndex) => _data.CopyTo(array, arrayIndex);
@@ -191,32 +214,37 @@ public readonly struct RecordCollection<T> :
   #endregion IImmutableList<T> implementation
 
   #region equality
+  [Pure]
   public override bool Equals(
     [NotNullWhen(true)] object? obj
   ) => obj is RecordCollection<T> recordCollection && Equals(recordCollection);
 
   /// <summary>Compares sequence-equality with any other <see cref="IImmutableList{T}"/>.</summary>
+  [Pure]
   public bool Equals(RecordCollection<T> other)
     => _data.SequenceEqual(other._data);
+  [Pure]
   public bool Equals(RecordCollection<T> other, IEqualityComparer<T> comparer)
     => _data.SequenceEqual(other._data, comparer);
 
+  [Pure]
   public static bool Equals(RecordCollection<T>? a, RecordCollection<T>? b)
     => RecordCollection.Equals(a, b);
 
   /// <summary>
   /// Gets/caches the combined <see cref="HashCode"/> of each item in the sequence.
   /// </summary>
+  [Pure]
   public override int GetHashCode() => GetHashCode(null);
 
+  [Pure]
   public int GetHashCode(IEqualityComparer<T>? comparer)
   {
     var hash = new HashCode();
 
     foreach (var item in _data)
-    {
       hash.Add(item, comparer);
-    }
+
     return hash.ToHashCode();
   }
 

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -55,10 +55,19 @@ public readonly struct RecordCollection<T> :
   /// <summary>true if-and-only-if the collection is empty.</summary>
   public bool IsEmpty => _data.IsEmpty;
   [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+  bool IList.IsFixedSize => true;
+  [DebuggerBrowsable(DebuggerBrowsableState.Never)]
   bool ICollection<T>.IsReadOnly => true;
+  [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+  bool IList.IsReadOnly => true;
   /// <summary>Number of elements in the collection.</summary>
   public int Count => _data.Length;
 
+  bool ICollection.IsSynchronized => true;
+  object ICollection.SyncRoot => ((ICollection)_data).SyncRoot;
+
+
+  [Pure]
   public T this[int index]
   {
     get => _data[index];
@@ -131,7 +140,7 @@ public readonly struct RecordCollection<T> :
 
   #endregion IImmutableList implementation overrides
 
-  #region IList implementation
+  #region IList<T> implementation
   void ICollection<T>.Add(T ele) => throw new NotSupportedException(ExceptionMessage.Immutable);
   void ICollection<T>.Clear() => throw new NotSupportedException(ExceptionMessage.Immutable);
   bool ICollection<T>.Remove(T item) => throw new NotSupportedException(ExceptionMessage.Immutable);
@@ -145,9 +154,28 @@ public readonly struct RecordCollection<T> :
   public void CopyTo(T[] array, int arrayIndex) => _data.CopyTo(array, arrayIndex);
   /// <summary>Copies the contents of this collection to a <see cref="Span{T}"/>.</summary>
   public void CopyTo(Span<T> destination) => _data.CopyTo(destination);
+  #endregion IList<T> implementation
+
+  #region IList implementation
+  object? IList.this[int index]
+  {
+    get => this[index];
+    [Obsolete($"Will throw '{ExceptionMessage.Immutable}'", error: true)]
+    set => throw new NotSupportedException(ExceptionMessage.Immutable);
+  }
+  bool IList.Contains(object? value) => value is T t && _data.Contains(t);
+  int IList.IndexOf(object? value) => value is T t ? _data.IndexOf(t) : -1;
+
+  void IList.Clear() => throw new NotSupportedException(ExceptionMessage.Immutable);
+  void IList.RemoveAt(int index) => throw new NotSupportedException(ExceptionMessage.Immutable);
+  int IList.Add(object? value) => throw new NotSupportedException(ExceptionMessage.Immutable);
+  void ICollection.CopyTo(Array array, int index) => throw new NotSupportedException(ExceptionMessage.Immutable);
+  void IList.Insert(int index, object? value) => throw new NotSupportedException(ExceptionMessage.Immutable);
+  void IList.Remove(object? value) => throw new NotSupportedException(ExceptionMessage.Immutable);
+
   #endregion IList implementation
 
-  #region IImmutableList implementation
+  #region IImmutableList<T> implementation
   IImmutableList<T> IImmutableList<T>.Add(T value) => Add(value);
   IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items) => AddRange(items);
   IImmutableList<T> IImmutableList<T>.Clear() => Clear();
@@ -160,7 +188,7 @@ public readonly struct RecordCollection<T> :
   IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) => RemoveRange(index, count);
   IImmutableList<T> IImmutableList<T>.Replace(T oldValue, T newValue, IEqualityComparer<T>? equalityComparer) => Replace(oldValue, newValue, equalityComparer);
   IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) => SetItem(index, value);
-  #endregion IImmutableList implementation
+  #endregion IImmutableList<T> implementation
 
   #region equality
   public override bool Equals(

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -235,19 +235,20 @@ public readonly struct RecordCollection<T> :
     if (other is null)
       return false;
 
-    if (comparer is IEqualityComparer<T> comparerOfT && other is IEnumerable<T> otherOfT)
+    if (other is IEnumerable<T> otherOfT)
     {
+      if (comparer is not IEqualityComparer<T> comparerOfT)
+        return SequenceEquals(otherOfT, comparer);
+
       if (other is RecordCollection<T> r)
         return _data.SequenceEqual(r._data, comparerOfT);
 
       return _data.SequenceEqual(otherOfT, comparerOfT);
+
     }
 
     if (other is IStructuralEquatable equatable)
       return ((IStructuralEquatable)this).GetHashCode(comparer) == equatable.GetHashCode(comparer);
-
-    if (other is IEnumerable<T> enumerableOfT)
-      return SequenceEquals(enumerableOfT, comparer);
 
     // TODO: handle IEnumerable<Other> better
     if (other is IEnumerable enumerable)

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -184,6 +184,26 @@ public readonly struct RecordCollection<T> :
     return hash.ToHashCode();
   }
 
+  /// <summary>
+  /// TODO: Experimental
+  /// </summary>
+  private static bool Equals<TOther>(RecordCollection<T> a, IEnumerable<TOther> other, IEqualityComparer comparer)
+  {
+    var myEnumerator = a._data.GetEnumerator();
+    var otherEnumerator = other.GetEnumerator();
+    using var otherEnumerator1 = otherEnumerator as IDisposable;
+
+    bool myStillGoing;
+    bool otherStillGoing = true;
+    while ((myStillGoing = myEnumerator.MoveNext()) && (otherStillGoing = otherEnumerator.MoveNext()))
+    {
+      if (!comparer.Equals(myEnumerator.Current, otherEnumerator.Current))
+        return false;
+    }
+
+    return !myStillGoing && !otherStillGoing;
+  }
+
   #endregion equality
 
   #region IStructuralEquatable
@@ -207,6 +227,9 @@ public readonly struct RecordCollection<T> :
 
     if (other is IStructuralEquatable equatable)
       return ((IStructuralEquatable)this).GetHashCode(comparer) == equatable.GetHashCode(comparer);
+
+    if (other is IEnumerable enumerable)
+      return Equals(this, enumerable.Cast<object>(), comparer);
 
     return false;
   }

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -8,46 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Org.Grush.Lib.RecordCollections;
 
-public static class RecordCollection
-{
-  /// <summary>Alternative to <see cref="RecordCollection{T}.Empty"/>.</summary>
-  public static RecordCollection<T> Create<T>()
-    => RecordCollection<T>.Empty;
-
-  /// <summary>
-  /// Public <see cref="RecordCollection{T}"/> initializer from <see cref="ReadOnlySpan{T}"/>,
-  /// used for collection expression syntax.
-  /// </summary>
-  public static RecordCollection<T> Create<T>(ReadOnlySpan<T> items)
-    => ImmutableArray.Create(items);
-
-  /// <inheritdoc cref="ToRecordCollection{T}(System.Collections.Generic.IEnumerable{T})"/>
-  public static RecordCollection<T> ToRecordCollection<T>(this ReadOnlySpan<T> items)
-    => [..items];
-
-  /// <summary>Produces a record collection from the specified elements, as a LINQ-like extensions.</summary>
-  public static RecordCollection<T> ToRecordCollection<T>(this IEnumerable<T> enumerable)
-    => CreateRange(enumerable);
-
-
-  /// <summary>Creates a new <see cref="RecordCollection{T}"/> from the specified elements.</summary>
-  public static RecordCollection<T> CreateRange<T>(IEnumerable<T> enumerable)
-  {
-    if (enumerable is RecordCollection<T> c)
-      return c;
-
-    return ImmutableArray.CreateRange(enumerable);
-  }
-
-  public static bool Equals<T>(RecordCollection<T>? lhs, RecordCollection<T>? rhs) =>
-    (lhs, rhs) switch
-    {
-      (null, null) => true,
-      (not null, not null) => lhs.Equals(rhs),
-      _ => false,
-    };
-}
-
 /// <summary>
 /// Collection type with record compatibility (value equal, immutable, de/serializable).
 ///

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.cs
@@ -12,7 +12,7 @@ namespace Org.Grush.Lib.RecordCollections;
 internal interface IRecordCollection : IList, IStructuralEquatable
 {
   [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-  internal ref readonly IStructuralEquatable InnerData { get; }
+  internal IStructuralEquatable InnerData { get; }
 }
 
 /// <summary>

--- a/Org.Grush.Lib.RecordCollections/RecordCollection.static.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollection.static.cs
@@ -1,0 +1,43 @@
+using System.Collections.Immutable;
+
+namespace Org.Grush.Lib.RecordCollections;
+
+public static class RecordCollection
+{
+  /// <summary>Alternative to <see cref="RecordCollection{T}.Empty"/>.</summary>
+  public static RecordCollection<T> Create<T>()
+    => RecordCollection<T>.Empty;
+
+  /// <summary>
+  /// Public <see cref="RecordCollection{T}"/> initializer from <see cref="ReadOnlySpan{T}"/>,
+  /// used for collection expression syntax.
+  /// </summary>
+  public static RecordCollection<T> Create<T>(ReadOnlySpan<T> items)
+    => ImmutableArray.Create(items);
+
+  /// <inheritdoc cref="ToRecordCollection{T}(System.Collections.Generic.IEnumerable{T})"/>
+  public static RecordCollection<T> ToRecordCollection<T>(this ReadOnlySpan<T> items)
+    => [..items];
+
+  /// <summary>Produces a record collection from the specified elements, as a LINQ-like extensions.</summary>
+  public static RecordCollection<T> ToRecordCollection<T>(this IEnumerable<T> enumerable)
+    => CreateRange(enumerable);
+
+
+  /// <summary>Creates a new <see cref="RecordCollection{T}"/> from the specified elements.</summary>
+  public static RecordCollection<T> CreateRange<T>(IEnumerable<T> enumerable)
+  {
+    if (enumerable is RecordCollection<T> c)
+      return c;
+
+    return ImmutableArray.CreateRange(enumerable);
+  }
+
+  public static bool Equals<T>(RecordCollection<T>? lhs, RecordCollection<T>? rhs) =>
+    (lhs, rhs) switch
+    {
+      (null, null) => true,
+      (not null, not null) => lhs.Equals(rhs),
+      _ => false,
+    };
+}

--- a/Org.Grush.Lib.RecordCollections/RecordCollectionExtensions.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollectionExtensions.cs
@@ -4,35 +4,32 @@ namespace Org.Grush.Lib.RecordCollections;
 
 public static class RecordCollectionExtensions
 {
-  public static bool SequenceEquals<TDerived, TBase>(this RecordCollection<TBase> source, RecordCollection<TDerived> other, IEqualityComparer<TBase>? comparer = null)
+  public static bool SequenceEqual<TDerived, TBase>(this RecordCollection<TBase> source, RecordCollection<TDerived> other, IEqualityComparer<TBase>? comparer = null)
     where TDerived : TBase
     => ((ImmutableArray<TBase>)source).SequenceEqual((ImmutableArray<TDerived>)other, comparer);
 
-  public static bool SequenceEquals<TDerived, TBase>(this RecordCollection<TBase> source, IEnumerable<TDerived> other, IEqualityComparer<TBase>? comparer = null)
+  public static bool SequenceEqual<TDerived, TBase>(this RecordCollection<TBase> source, IEnumerable<TDerived> other, IEqualityComparer<TBase>? comparer = null)
     where TDerived : TBase
     => ((ImmutableArray<TBase>)source).SequenceEqual(other, comparer);
 
-  public static bool SequenceEquals<TDerived, TBase>(this RecordCollection<TBase> source, RecordCollection<TDerived> other, Func<TBase, TBase, bool> predicate)
+  public static bool SequenceEqual<TDerived, TBase>(this RecordCollection<TBase> source, RecordCollection<TDerived> other, Func<TBase, TBase, bool> predicate)
     where TDerived : TBase
     => ((ImmutableArray<TBase>)source).SequenceEqual((ImmutableArray<TDerived>)other, predicate);
-
-  public static RecordCollection<
-#nullable disable
-    TResult
-#nullable restore
-  > Cast<TBase, TResult>(this RecordCollection<TBase> source)
-    where TResult : class?
-  {
-    var src = (ImmutableArray<TBase>)source;
-
-    return (RecordCollection<TResult>)src.As<TResult>();
-  }
 
   public static IEnumerable<TResult> Select<T, TResult>(this RecordCollection<T> source, Func<T, TResult> selector)
     => ((ImmutableArray<T>)source).Select(selector);
 
   public static IEnumerable<T> Where<T>(this RecordCollection<T> source, Func<T, bool> predicate)
     => ((ImmutableArray<T>)source).Where(predicate);
+
+  public static Dictionary<TKey, T> ToDictionary<TKey, T>(
+    this RecordCollection<T> source,
+    Func<T, TKey> keySelector,
+    IEqualityComparer<TKey>? comparer = null
+  ) where TKey : notnull
+  {
+    return ((ImmutableArray<T>)source).ToDictionary(keySelector, t => t, comparer);
+  }
 
   public static Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(
     this RecordCollection<T> source,

--- a/Org.Grush.Lib.RecordCollections/RecordCollectionExtensions.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollectionExtensions.cs
@@ -1,0 +1,49 @@
+using System.Collections.Immutable;
+
+namespace Org.Grush.Lib.RecordCollections;
+
+public static class RecordCollectionExtensions
+{
+  public static bool SequenceEquals<TDerived, TBase>(this RecordCollection<TBase> source, RecordCollection<TDerived> other, IEqualityComparer<TBase>? comparer = null)
+    where TDerived : TBase
+    => ((ImmutableArray<TBase>)source).SequenceEqual((ImmutableArray<TDerived>)other, comparer);
+
+  public static bool SequenceEquals<TDerived, TBase>(this RecordCollection<TBase> source, IEnumerable<TDerived> other, IEqualityComparer<TBase>? comparer = null)
+    where TDerived : TBase
+    => ((ImmutableArray<TBase>)source).SequenceEqual(other, comparer);
+
+  public static bool SequenceEquals<TDerived, TBase>(this RecordCollection<TBase> source, RecordCollection<TDerived> other, Func<TBase, TBase, bool> predicate)
+    where TDerived : TBase
+    => ((ImmutableArray<TBase>)source).SequenceEqual((ImmutableArray<TDerived>)other, predicate);
+
+  public static RecordCollection<
+#nullable disable
+    TResult
+#nullable restore
+  > Cast<TBase, TResult>(this RecordCollection<TBase> source)
+    where TResult : class?
+  {
+    var src = (ImmutableArray<TBase>)source;
+
+    return (RecordCollection<TResult>)src.As<TResult>();
+  }
+
+  public static IEnumerable<TResult> Select<T, TResult>(this RecordCollection<T> source, Func<T, TResult> selector)
+    => ((ImmutableArray<T>)source).Select(selector);
+
+  public static IEnumerable<T> Where<T>(this RecordCollection<T> source, Func<T, bool> predicate)
+    => ((ImmutableArray<T>)source).Where(predicate);
+
+  public static Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(
+    this RecordCollection<T> source,
+    Func<T, TKey> keySelector,
+    Func<T, TElement> elementSelector,
+    IEqualityComparer<TKey>? comparer = null
+    ) where TKey : notnull
+  {
+    return ((ImmutableArray<T>)source).ToDictionary(keySelector, elementSelector, comparer);
+  }
+
+  public static T[] ToArray<T>(this RecordCollection<T> source)
+    => ((ImmutableArray<T>)source).ToArray();
+}

--- a/Org.Grush.Lib.RecordCollections/RecordCollectionJsonConverterFactory.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollectionJsonConverterFactory.cs
@@ -4,8 +4,12 @@ using System.Text.Json.Serialization;
 
 namespace Org.Grush.Lib.RecordCollections;
 
+/// <summary>
+/// Dynamically resolve <see cref="RecordCollectionStrictJsonConverter{T}"/>s
+/// if not in AOT mode.
+/// </summary>
 #if NET8_0_OR_GREATER
-[System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Dynamically references generic types that may not be available at runtime.")]
+[System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Dynamically references generic RecordCollection<> for determining if factory can deserialize type.")]
 #endif
 public class RecordCollectionJsonConverterFactory : JsonConverterFactory
 {
@@ -18,9 +22,9 @@ public class RecordCollectionJsonConverterFactory : JsonConverterFactory
     Type elementType = typeToConvert.GetGenericArguments()[0];
 
     return Activator.CreateInstance(
-      typeof(RecordCollectionStrictJsonConverter<>).MakeGenericType([
+      typeof(RecordCollectionStrictJsonConverter<>).MakeGenericType(
         elementType
-      ]),
+      ),
       BindingFlags.Instance | BindingFlags.Public,
       binder: null,
       args: [],

--- a/Org.Grush.Lib.RecordCollections/RecordCollectionStrictJsonConverter.cs
+++ b/Org.Grush.Lib.RecordCollections/RecordCollectionStrictJsonConverter.cs
@@ -3,6 +3,12 @@ using System.Text.Json.Serialization;
 
 namespace Org.Grush.Lib.RecordCollections;
 
+/// <summary>
+/// An overly-strict <see cref="JsonConverter"/> for de/serializing <see cref="RecordCollection{T}"/>s.
+/// Requires that the JSON environment be able to provide a <see cref="JsonConverter{T}"/>,
+/// which may be a problem for more-complex collections.
+/// </summary>
+/// <typeparam name="T">The type of element in the collection.</typeparam>
 #if NET8_0_OR_GREATER
 [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON de/serialization requires references to type T which may not be statically analyzed.")]
 [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON de/serialization requires a JsonConverter for <T>, which cannot be statically analyzed. For AOT, use this in a JsonSerializerContext partial in the Converters list on the JsonSourceGenerationOptionsAttribute.")]
@@ -33,14 +39,15 @@ public class RecordCollectionStrictJsonConverter<T> : JsonConverter<RecordCollec
       );
     }
 
+    // TODO: is this the correct exit approach? We can't exit with an incomplete RecordCollection...
     throw new JsonException("Bad json end; expected EndArray but reached end of sequence.");
   }
 
   public override void Write(Utf8JsonWriter writer, RecordCollection<T> value, JsonSerializerOptions options)
   {
     writer.WriteStartArray();
-    var subConverter = GetSubConverter(options);
 
+    var subConverter = GetSubConverter(options);
     foreach (T subValue in value)
       subConverter.Write(writer, subValue, options);
 

--- a/Org.Grush.Lib.RecordCollections/Shims.cs
+++ b/Org.Grush.Lib.RecordCollections/Shims.cs
@@ -5,7 +5,7 @@ namespace Org.Grush.Lib.RecordCollections;
 /// <summary>
 /// Shim for
 /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.notnullwhenattribute?view=netstandard-2.1">NotNullWhenAttribute</see>
-/// from the stdlib. Not worth bringin in the packaged version.
+/// from the stdlib. Not worth bringing in the packaged version.
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
 internal sealed class NotNullWhenAttribute(bool returnValue) : Attribute


### PR DESCRIPTION
Documentation:
* added links to NuGet and GitHub source in both READMEs
* document the equals rules

Non-functional changes:
* `RecordCollectionNewtonsoftJsonConverter<T>#WriteJson()` is effectively inaccessible, so it throws `NotSupportedException`
* move static class to its own file
* marked all pure methods as `[Pure]`

Functional changes:
* `RecordCollection` now extends `IList`, the non-generic one
* enhancements to `IStructuralEquality`
   - supports type-optimized checks, RecordCollection checks, cross-type checks and fallback to deoptimized `IStructuralEquatable#GetHashCode()` checks.
* trying to index-set is a compiler error
* New methods:
  - `As<TOther>()`
  - `UntypedSequenceEqual(IEnumerable, IEqualityComparer)` compares sequences regardless of type.
  - `static RecordCollection<T>.CastUp(RecordCollection<TDerived>)`
* New extension methods:
  - `SequenceEqual` against related type in a collection or enumerable using an `IEqualityComparer` or a function.
  - Optimized versions of `Select`, `Where`, `ToDictionary`, and `ToArray`

Testing:
* 100% code coverage
* all tests/classes converted to static
* introduce Moq (yeah yeah)
* code coverage reporter